### PR TITLE
Fix misleading comment in test

### DIFF
--- a/tests/core_tests/test_response_parser.py
+++ b/tests/core_tests/test_response_parser.py
@@ -28,9 +28,8 @@ def test_parse_response_unknown_type():
     assert result == str(obj)
 
 def test_parse_response_malformed_key(monkeypatch):
-    # Simuliere, dass der Zugriff auf response_json eine Exception wirft
+    # Ein leeres Dict löst einen KeyError aus und testet so den Error-Pfad
     bad_json = {}
-    # monkeypatch, damit der KeyError propagiert wird und im except abgefangen wird
     result = parse_response("openai", bad_json)
     assert result.startswith("[Parse error]:")
 


### PR DESCRIPTION
## Summary
- update comment in `test_response_parser` to clarify that an empty dict hits the error path

## Testing
- `pip install -r requirements.txt`
- `pip install flask_sqlalchemy`
- `pytest -q` *(fails: tests/test_web_app.py::test_plan_success)*

------
https://chatgpt.com/codex/tasks/task_e_683f8307ef0c832f84e67290b494c9f8