### PR TITLE
Fix verb in response parser docstring

### DIFF
--- a/core/response_parser.py
+++ b/core/response_parser.py
@@ -11,7 +11,7 @@ from typing import Any, Dict
 
 def parse_response(api_type: str, response_json: Dict[str, Any]) -> Any:
     """
-    Parsed die JSON-Antwort einer AI-API und extrahiert den eigentlichen Inhalt.
+    Parst die JSON-Antwort einer AI-API und extrahiert den eigentlichen Inhalt.
 
     Unterstützte API-Typen:
       - "openai" : Erwartet ein 'choices'-Array mit einer 'message.content'


### PR DESCRIPTION
## Summary
- fix a German typo in `parse_response` docstring

## Testing
- `pip install -r requirements.txt`
- `pip install Flask-SQLAlchemy`
- `pytest -q` *(fails: test_plan_success)*

------
https://chatgpt.com/codex/tasks/task_e_683f83074098832fbeeabf179563a649