### PR TITLE
Add GitLab issue creation from UI

### DIFF
--- a/scripts/gitlab_issues.py
+++ b/scripts/gitlab_issues.py
@@ -3,7 +3,9 @@ import json
 import requests
 
 
-def create_issue(title: str, description: str, gitlab_url: str, project_id: str, token: str) -> dict:
+def create_issue(
+    title: str, description: str, gitlab_url: str, project_id: str, token: str
+) -> dict:
     """Create a single GitLab issue via the API."""
     api = f"{gitlab_url}/api/v4/projects/{project_id}/issues"
     headers = {"PRIVATE-TOKEN": token}
@@ -13,29 +15,62 @@ def create_issue(title: str, description: str, gitlab_url: str, project_id: str,
     return response.json()
 
 
-def create_issues_from_tickets(tickets_file: str) -> None:
-    """Create GitLab issues for each ticket in tickets_file."""
+def create_issues_from_tickets(
+    tickets_file: str,
+    gitlab_url: str | None = None,
+    project_id: str | None = None,
+    token: str | None = None,
+) -> list:
+    """Create GitLab issues for each ticket in ``tickets_file``.
+
+    Parameters fall back to environment variables if not provided.
+    Returns a list with the created issue JSON objects.
+    """
     with open(tickets_file, encoding="utf-8") as f:
         tickets = json.load(f)
 
-    url = os.getenv("GITLAB_URL", "https://gitlab.com")
-    project_id = os.environ["GITLAB_PROJECT_ID"]
-    token = os.environ["GITLAB_TOKEN"]
+    url = gitlab_url or os.getenv("GITLAB_URL", "https://gitlab.com")
+    project = project_id or os.environ.get("GITLAB_PROJECT_ID")
+    tok = token or os.environ.get("GITLAB_TOKEN")
 
+    if not project or not tok:
+        raise ValueError("GitLab project ID und Token erforderlich")
+
+    issues = []
     for ticket in tickets:
         title = ticket.get("title", "Untitled")
         desc = ticket.get("beschreibung", "")
         reqs = ticket.get("anforderungen", "")
         body = f"{desc}\n\n{reqs}" if reqs else desc
-        issue = create_issue(title, body, url, project_id, token)
-        print(f"Created issue #{issue['iid']}: {issue['web_url']}")
+        issue = create_issue(title, body, url, project, tok)
+        issues.append(issue)
+    return issues
 
 
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Create GitLab issues from tickets.json")
+    parser = argparse.ArgumentParser(
+        description="Create GitLab issues from tickets.json"
+    )
     parser.add_argument("tickets_file", help="Path to tickets.json")
+    parser.add_argument(
+        "--gitlab-url",
+        dest="gitlab_url",
+        default=os.getenv("GITLAB_URL", "https://gitlab.com"),
+        help="GitLab URL",
+    )
+    parser.add_argument(
+        "--project-id",
+        dest="project_id",
+        default=os.getenv("GITLAB_PROJECT_ID"),
+        help="GitLab project ID",
+    )
+    parser.add_argument(
+        "--token", dest="token", default=os.getenv("GITLAB_TOKEN"), help="GitLab token"
+    )
     args = parser.parse_args()
 
-    create_issues_from_tickets(args.tickets_file)
+    create_issues_from_tickets(
+        args.tickets_file, args.gitlab_url, args.project_id, args.token
+    )

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,6 +29,12 @@
       <input type="text" id="api_url"  placeholder="API-URL">
       <input type="text" id="api_key" placeholder="API-Key (optional)">
       <input type="text" id="model"   placeholder="Modell (optional)">
+
+      <h3>GitLab</h3>
+      <input type="text" id="gitlab_url" placeholder="GitLab-URL (optional)">
+      <input type="text" id="gitlab_project_id" placeholder="Projekt-ID">
+      <input type="text" id="gitlab_token" placeholder="Token">
+      <button id="gitlab-btn" disabled>Issues erstellen</button>
     </aside>
 
     <main class="ide-main">
@@ -276,6 +282,31 @@
       }
 
       await loadStructure();
+      btn.disabled = false;
+      document.getElementById("gitlab-btn").disabled = false;
+    };
+
+    document.getElementById("gitlab-btn").onclick = async () => {
+      const btn = document.getElementById("gitlab-btn");
+      btn.disabled = true;
+      btn.textContent = "⏳ Erstelle Issues…";
+      const resp = await fetch("/gitlab_issues", {
+        method: "POST",
+        headers: {"Content-Type":"application/json"},
+        body: JSON.stringify({
+          project_folder: projectFolder,
+          gitlab_url: document.getElementById("gitlab_url").value.trim(),
+          gitlab_project_id: document.getElementById("gitlab_project_id").value.trim(),
+          gitlab_token: document.getElementById("gitlab_token").value.trim()
+        })
+      });
+      const data = await resp.json();
+      if (resp.ok && Array.isArray(data.issues)) {
+        btn.textContent = "Issues erstellt";
+      } else {
+        btn.textContent = "Fehler";
+        alert(data.error || resp.statusText);
+      }
       btn.disabled = false;
     };
   </script>

--- a/web_app.py
+++ b/web_app.py
@@ -7,26 +7,27 @@ Es beinhaltet:
 """
 
 import os
-from flask import (
-    Flask, render_template, request,
-    jsonify, redirect, url_for, flash
-)
+from flask import Flask, render_template, request, jsonify, redirect, url_for, flash
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import (
-    LoginManager, login_user, login_required,
-    logout_user, current_user
+    LoginManager,
+    login_user,
+    login_required,
+    logout_user,
+    current_user,
 )
 from models import db, User, APIKey
 from storage.project_storage import create_project_structure
-from storage.plan_storage    import save_plan
-from storage.ticket_storage  import save_tickets
-from storage.test_storage    import save_tests
-from storage.code_storage    import save_code
-from storage.saver           import save_response
-from planner.planner         import generate_project_plan
+from storage.plan_storage import save_plan
+from storage.ticket_storage import save_tickets
+from storage.test_storage import save_tests
+from storage.code_storage import save_code
+from storage.saver import save_response
+from planner.planner import generate_project_plan
 from planner.ticket_generator import generate_tickets
-from planner.test_generator   import generate_tests
-from planner.code_generator   import generate_code_for_ticket
+from planner.test_generator import generate_tests
+from planner.code_generator import generate_code_for_ticket
+from scripts.gitlab_issues import create_issues_from_tickets
 
 
 def create_app(config: dict = None) -> Flask:
@@ -39,16 +40,12 @@ def create_app(config: dict = None) -> Flask:
     Returns:
         Flask: Die initialisierte Flask-Applikation.
     """
-    app = Flask(
-        __name__,
-        template_folder="templates",
-        static_folder="static"
-    )
+    app = Flask(__name__, template_folder="templates", static_folder="static")
 
     app.config.update(
         SECRET_KEY="replace-with-your-secret",
         SQLALCHEMY_DATABASE_URI="sqlite:///users.db",
-        SQLALCHEMY_TRACK_MODIFICATIONS=False
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
     )
     if config:
         app.config.update(config)
@@ -66,58 +63,58 @@ def create_app(config: dict = None) -> Flask:
         """Callback für flask-login, um den aktuellen Benutzer anhand seiner ID zu laden."""
         return User.query.get(int(user_id))
 
-    @app.route('/register', methods=['GET', 'POST'])
+    @app.route("/register", methods=["GET", "POST"])
     def register():
         """
         GET:  Liefert die Registrierungsseite.
         POST: Legt bei gültigen Eingaben einen neuen User an und loggt ihn ein.
         """
-        if request.method == 'POST':
-            username = request.form['username'].strip()
-            password = request.form['password']
+        if request.method == "POST":
+            username = request.form["username"].strip()
+            password = request.form["password"]
             if not username or not password:
-                flash('Benutzername und Passwort erforderlich.')
-                return redirect(url_for('register'))
+                flash("Benutzername und Passwort erforderlich.")
+                return redirect(url_for("register"))
             if User.query.filter_by(username=username).first():
-                flash('Benutzername existiert bereits.')
-                return redirect(url_for('register'))
+                flash("Benutzername existiert bereits.")
+                return redirect(url_for("register"))
             user = User(username=username)
             user.set_password(password)
             db.session.add(user)
             db.session.commit()
             login_user(user)
-            return redirect(url_for('index'))
-        return render_template('register.html')
+            return redirect(url_for("index"))
+        return render_template("register.html")
 
-    @app.route('/login', methods=['GET', 'POST'])
+    @app.route("/login", methods=["GET", "POST"])
     def login():
         """
         GET:  Liefert die Login-Seite.
         POST: Prüft Zugangsdaten und loggt den User ein.
         """
-        if request.method == 'POST':
-            username = request.form['username'].strip()
-            password = request.form['password']
+        if request.method == "POST":
+            username = request.form["username"].strip()
+            password = request.form["password"]
             user = User.query.filter_by(username=username).first()
             if not user or not user.check_password(password):
-                flash('Ungültige Zugangsdaten.')
-                return redirect(url_for('login'))
+                flash("Ungültige Zugangsdaten.")
+                return redirect(url_for("login"))
             login_user(user)
-            return redirect(url_for('index'))
-        return render_template('login.html')
+            return redirect(url_for("index"))
+        return render_template("login.html")
 
-    @app.route('/logout')
+    @app.route("/logout")
     @login_required
     def logout():
         """Loggt den aktuellen Benutzer aus und leitet zur Login-Seite weiter."""
         logout_user()
-        return redirect(url_for('login'))
+        return redirect(url_for("login"))
 
-    @app.route('/')
+    @app.route("/")
     @login_required
     def index():
         """Startseite der Anwendung; zeigt das Dashboard mit Benutzernamen."""
-        return render_template('index.html', username=current_user.username)
+        return render_template("index.html", username=current_user.username)
 
     def _get_api_key(api_url: str, provided_key: str, model: str) -> str:
         """
@@ -133,8 +130,7 @@ def create_app(config: dict = None) -> Flask:
         """
         if provided_key:
             rec = APIKey.query.filter_by(
-                user_id=current_user.id,
-                api_url=api_url
+                user_id=current_user.id, api_url=api_url
             ).first()
             if rec:
                 rec.api_key_value = provided_key
@@ -144,29 +140,26 @@ def create_app(config: dict = None) -> Flask:
                     api_url=api_url,
                     api_key_value=provided_key,
                     model=model,
-                    user_id=current_user.id
+                    user_id=current_user.id,
                 )
                 db.session.add(rec)
             db.session.commit()
             return provided_key
 
-        rec = APIKey.query.filter_by(
-            user_id=current_user.id,
-            api_url=api_url
-        ).first()
+        rec = APIKey.query.filter_by(user_id=current_user.id, api_url=api_url).first()
         return rec.api_key_value if rec else ""
 
-    @app.route('/plan', methods=['POST'])
+    @app.route("/plan", methods=["POST"])
     @login_required
     def plan():
-        data      = request.json or {}
-        api_url   = data.get('api_url', '').strip()
-        api_key   = data.get('api_key', '').strip()
-        model     = data.get('model', '').strip()
-        name      = data.get('project_name', '').strip()
-        desc      = data.get('project_desc', '').strip()
-        project   = data.get('project', '').strip()
-        base_path = data.get('project_path', '').strip()
+        data = request.json or {}
+        api_url = data.get("api_url", "").strip()
+        api_key = data.get("api_key", "").strip()
+        model = data.get("model", "").strip()
+        name = data.get("project_name", "").strip()
+        desc = data.get("project_desc", "").strip()
+        project = data.get("project", "").strip()
+        base_path = data.get("project_path", "").strip()
 
         # Fallback: unterstützt alte API mit einfachem "project"-Feld
         if project:
@@ -186,32 +179,29 @@ def create_app(config: dict = None) -> Flask:
                 project_folder = create_project_structure(name, base_path)
             else:
                 project_folder = create_project_structure(name)
-            project_text   = f"{name}\n{desc}"
-            plan_text      = generate_project_plan(api_url, key, project_text, model)
+            project_text = f"{name}\n{desc}"
+            plan_text = generate_project_plan(api_url, key, project_text, model)
 
             save_plan(project_folder, plan_text)
             save_response(project_folder, project_text, plan_text)
-            return jsonify({
-                "plan":           plan_text,
-                "project_folder": project_folder
-            }), 200
+            return jsonify({"plan": plan_text, "project_folder": project_folder}), 200
 
         except Exception as e:
             return jsonify({"error": str(e)}), 500
 
-    @app.route('/tickets', methods=['POST'])
+    @app.route("/tickets", methods=["POST"])
     @login_required
     def tickets():
         """
         Generiert Tickets aus einem vorhandenen Projektplan-Text,
         speichert sie und liefert die Liste zurück.
         """
-        data           = request.json or {}
-        api_url        = data.get('api_url', '').strip()
-        api_key        = data.get('api_key', '').strip()
-        model          = data.get('model', '').strip()
-        project_folder = data.get('project_folder', '').strip()
-        plan_text      = data.get('plan_text', '').strip()
+        data = request.json or {}
+        api_url = data.get("api_url", "").strip()
+        api_key = data.get("api_key", "").strip()
+        model = data.get("model", "").strip()
+        project_folder = data.get("project_folder", "").strip()
+        plan_text = data.get("plan_text", "").strip()
 
         if not api_url or not project_folder or not plan_text:
             return jsonify(error="Fehlende Daten"), 400
@@ -227,66 +217,96 @@ def create_app(config: dict = None) -> Flask:
         except Exception:
             return jsonify(error="Unbekannter Fehler beim Ticket-Generieren."), 500
 
-    @app.route('/generate_tests', methods=['POST'])
+    @app.route("/generate_tests", methods=["POST"])
     @login_required
     def gen_tests():
         """
         Generiert pytest-Tests für ein einzelnes Ticket,
         speichert die Tests und gibt Pfad & Inhalt zurück.
         """
-        data           = request.json or {}
-        api_url        = data.get('api_url', '').strip()
-        api_key        = data.get('api_key', '').strip()
-        model          = data.get('model', '').strip()
-        project_folder = data.get('project_folder', '').strip()
-        ticket_obj     = data.get('ticket')
+        data = request.json or {}
+        api_url = data.get("api_url", "").strip()
+        api_key = data.get("api_key", "").strip()
+        model = data.get("model", "").strip()
+        project_folder = data.get("project_folder", "").strip()
+        ticket_obj = data.get("ticket")
 
         if not api_url or not project_folder or not ticket_obj:
             return jsonify(error="API-URL, Projektordner und Ticket erforderlich."), 400
 
         key = _get_api_key(api_url, api_key, model)
         try:
-            tests_md   = generate_tests(api_url, key, ticket_obj, model)
+            tests_md = generate_tests(api_url, key, ticket_obj, model)
             tests_file = save_tests(project_folder, ticket_obj["file_path"], tests_md)
             save_response(project_folder, ticket_obj["file_path"], tests_md)
             return jsonify(tests=tests_md, saved_test=tests_file), 200
         except Exception as e:
             return jsonify(error=str(e)), 500
 
-    @app.route('/generate_code', methods=['POST'])
+    @app.route("/generate_code", methods=["POST"])
     @login_required
     def gen_code():
         """
         Generiert Code für ein einzelnes Ticket,
         speichert die Datei und gibt Pfad & Inhalt zurück.
         """
-        data           = request.json or {}
-        api_url        = data.get('api_url', '').strip()
-        api_key        = data.get('api_key', '').strip()
-        model          = data.get('model', '').strip()
-        project_folder = data.get('project_folder', '').strip()
-        ticket_obj     = data.get('ticket')
+        data = request.json or {}
+        api_url = data.get("api_url", "").strip()
+        api_key = data.get("api_key", "").strip()
+        model = data.get("model", "").strip()
+        project_folder = data.get("project_folder", "").strip()
+        ticket_obj = data.get("ticket")
 
         if not api_url or not project_folder or not ticket_obj:
             return jsonify(error="API-URL, Projektordner und Ticket erforderlich."), 400
 
         key = _get_api_key(api_url, api_key, model)
         try:
-            code_md   = generate_code_for_ticket(api_url, key, project_folder, ticket_obj, model)
+            code_md = generate_code_for_ticket(
+                api_url, key, project_folder, ticket_obj, model
+            )
             code_file = save_code(project_folder, ticket_obj["file_path"], code_md)
             save_response(project_folder, ticket_obj["file_path"], code_md)
             return jsonify(code=code_md, saved_to=code_file), 200
         except Exception as e:
             return jsonify(error=str(e)), 500
 
-    @app.route('/structure', methods=['POST'])
+    @app.route("/gitlab_issues", methods=["POST"])
+    @login_required
+    def gitlab_issues():
+        """Create GitLab issues from saved tickets."""
+        data = request.json or {}
+        project_folder = data.get("project_folder", "").strip()
+        gitlab_url = data.get("gitlab_url", "").strip() or "https://gitlab.com"
+        project_id = data.get("gitlab_project_id", "").strip()
+        token = data.get("gitlab_token", "").strip()
+
+        if not project_folder or not project_id or not token:
+            return (
+                jsonify(error="Projektordner, Projekt-ID und Token erforderlich."),
+                400,
+            )
+
+        tickets_file = os.path.join(project_folder, "tickets", "tickets.json")
+        if not os.path.exists(tickets_file):
+            return jsonify(error="tickets.json nicht gefunden."), 400
+
+        try:
+            issues = create_issues_from_tickets(
+                tickets_file, gitlab_url, project_id, token
+            )
+            return jsonify(issues=issues), 200
+        except Exception as e:
+            return jsonify(error=str(e)), 500
+
+    @app.route("/structure", methods=["POST"])
     @login_required
     def structure():
         """
         Gibt die Ordner- und Dateistruktur des Projekts als JSON-Tree zurück.
         """
-        data           = request.json or {}
-        project_folder = data.get('project_folder', '').strip()
+        data = request.json or {}
+        project_folder = data.get("project_folder", "").strip()
 
         if not project_folder:
             return jsonify(error="Projektordner erforderlich."), 400
@@ -295,7 +315,7 @@ def create_app(config: dict = None) -> Flask:
         for root, dirs, files in os.walk(project_folder):
             rel = os.path.relpath(root, project_folder)
             node = tree
-            if rel != '.':
+            if rel != ".":
                 for part in rel.split(os.sep):
                     node = node.setdefault(part, {})
             for d in dirs:
@@ -304,15 +324,15 @@ def create_app(config: dict = None) -> Flask:
                 node[f] = None
         return jsonify(structure=tree), 200
 
-    @app.route('/file_content', methods=['POST'])
+    @app.route("/file_content", methods=["POST"])
     @login_required
     def file_content():
         """
         Liest den Inhalt einer Datei im Projektverzeichnis und liefert ihn als Text zurück.
         """
-        data           = request.json or {}
-        project_folder = data.get('project_folder', '').strip()
-        file_path      = data.get('file_path', '').strip()
+        data = request.json or {}
+        project_folder = data.get("project_folder", "").strip()
+        file_path = data.get("file_path", "").strip()
 
         if not project_folder or not file_path:
             return jsonify(error="Projektordner und file_path erforderlich."), 400


### PR DESCRIPTION
## Summary
- add optional GitLab url, project ID and token fields in sidebar
- enable creating GitLab issues directly via new `/gitlab_issues` route
- expose parameters for create_issues_from_tickets and extend CLI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f899af3c8832f9c96261cb5f4517d